### PR TITLE
fix: do not abort in case of errors

### DIFF
--- a/.github/workflows/links-watcher-cron.yml
+++ b/.github/workflows/links-watcher-cron.yml
@@ -19,7 +19,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          fail: true
           args: --verbose --no-progress --exclude-mail --exclude-loopback .
           output: ./lychee/out.md
         env:


### PR DESCRIPTION
Remove "abort on error" in lychee check